### PR TITLE
PHP7: Incorrect size of string when recursiving get_neighbor

### DIFF
--- a/geohash.c
+++ b/geohash.c
@@ -325,8 +325,11 @@ get_neighbor(char *hash, int direction)
     base[0] = '\0';
     strncat(base, hash, hash_length - 1);
     
-    if(index_for_char(last_char, border[direction]) != -1)
-        base = get_neighbor(base, direction);
+    if(index_for_char(last_char, border[direction]) != -1){
+        char *base_temp = get_neighbor(base, direction);
+        strcpy( base, base_temp );
+        efree( base_temp );
+    }
     
     int neighbor_index = index_for_char(last_char, neighbor[direction]);
     last_char = char_map[neighbor_index];


### PR DESCRIPTION
The length is shorter if you call get_neighbor inside it, and it may not be free after using, so I copied it and free the temp variable.
I do not know how to debug extension, so printf is my primary way, and:
```
sudo phpize && ./configure && make && make install && brew services restart php71 && php -r "var_dump(geohash_neighbors('wx4dvpu4'));"
```
I'm new to pull requests, hope it is a better fix.